### PR TITLE
Add index on publishedAt and tags

### DIFF
--- a/src/Document/Post.php
+++ b/src/Document/Post.php
@@ -26,6 +26,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  */
 #[ODM\Document(repositoryClass: PostRepository::class)]
 #[ODM\UniqueIndex(keys: ['slug' => 1], options: ['unique' => true])]
+#[ODM\Index(['order' => 'desc', 'tags.name' => 'asc'])]
 #[Unique(fields: ['slug'], message: 'post.slug_unique', errorPath: 'title')]
 class Post
 {


### PR DESCRIPTION
The index covers the query made in `PostRepository::findLatest`:
* Range filter on `publishedAt`
* (optional) equality filter on `tags.name`
* Sort on `publishedAt`

Note: this change has definitely not been tested.